### PR TITLE
WIP: Feat/crv4 timelocked weights

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/bittensor-drand"]
+	path = third_party/bittensor-drand
+	url = https://github.com/tb-team-dev-2/bittensor-drand

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Makefile for gobt project
+
+CR_DRAND := third_party/bittensor-drand
+
+# Build CRv4 bindings without Python dependencies
+.PHONY: crv4
+crv4:
+	cd $(CR_DRAND) && \
+	cargo build --release --no-default-features
+
+# Clean CRv4 build artifacts
+.PHONY: clean-crv4
+clean-crv4:
+	cd $(CR_DRAND) && cargo clean
+
+# Generate C bindings header
+.PHONY: bindings
+bindings:
+	cd $(CR_DRAND) && \
+	cbindgen --crate bittensor_drand --output bindings.h
+
+# Build everything
+.PHONY: all
+all: crv4
+
+# Clean everything
+.PHONY: clean
+clean: clean-crv4

--- a/extrinsics/admin_utils.go
+++ b/extrinsics/admin_utils.go
@@ -705,3 +705,31 @@ func SudoSetSubnetOwnerCutExt(c *client.Client, subnet_owner_cut types.U16) (*ex
 	ext := extrinsic.NewExtrinsic(call)
 	return &ext, nil
 }
+
+// SudoSetCommitRevealWeightsEnabledCall creates the call for sudo_set_commit_reveal_weights_enabled
+func SudoSetCommitRevealWeightsEnabledCall(c *client.Client, netuid types.U16, enabled bool) (types.Call, error) {
+	call, err := types.NewCall(
+		c.Meta,
+		"AdminUtils.sudo_set_commit_reveal_weights_enabled",
+		netuid,
+		types.NewBool(enabled),
+	)
+	if err != nil {
+		return types.Call{}, err
+	}
+	return call, nil
+}
+
+// SudoSetWeightsSetRateLimitCall creates the call for sudo_set_weights_set_rate_limit  
+func SudoSetWeightsSetRateLimitCall(c *client.Client, netuid types.U16, weightsSetRateLimit types.U64) (types.Call, error) {
+	call, err := types.NewCall(
+		c.Meta,
+		"AdminUtils.sudo_set_weights_set_rate_limit",
+		netuid,
+		weightsSetRateLimit,
+	)
+	if err != nil {
+		return types.Call{}, err
+	}
+	return call, nil
+}

--- a/extrinsics/subtensor_module.go
+++ b/extrinsics/subtensor_module.go
@@ -20,7 +20,8 @@ import (
 //     - [ ] batch_commit_weights (Index: 100)
 //     - [ ] reveal_weights (Index: 97)
 
-//     - [ ] commit_crv3_weights (Index: 99)
+//     - [x] commit_crv3_weights (Index: 99)
+//     - [x] commit_timelocked_weights
 
 //     - [ ] batch_reveal_weights (Index: 98)
 //     - [ ] set_tao_weights (Index: 8)
@@ -320,6 +321,32 @@ func CommitCRV3WeightsCall(c *client.Client, netuid types.U16, commit types.Byte
 
 func CommitCRV3WeightsExt(c *client.Client, netuid types.U16, commit types.Bytes, revealRound types.U64) (*extrinsic.Extrinsic, error) {
 	call, err := CommitCRV3WeightsCall(c, netuid, commit, revealRound)
+	if err != nil {
+		return nil, err
+	}
+	ext := extrinsic.NewExtrinsic(call)
+	return &ext, nil
+}
+
+// CommitTimelockedWeightsCall creates the call for commit_timelocked_weights extrinsic
+func CommitTimelockedWeightsCall(c *client.Client, netuid types.U16, commit types.Bytes, revealRound types.U64) (types.Call, error) {
+	call, err := types.NewCall(
+		c.Meta,
+		"SubtensorModule.commit_timelocked_weights",
+		netuid,
+		commit,
+		revealRound,
+	)
+	if err != nil {
+		return types.Call{}, err
+	}
+
+	return call, nil
+}
+
+// CommitTimelockedWeightsExt creates the extrinsic for commit_timelocked_weights
+func CommitTimelockedWeightsExt(c *client.Client, netuid types.U16, commit types.Bytes, revealRound types.U64) (*extrinsic.Extrinsic, error) {
+	call, err := CommitTimelockedWeightsCall(c, netuid, commit, revealRound)
 	if err != nil {
 		return nil, err
 	}

--- a/extrinsics/subtensor_module_test.go
+++ b/extrinsics/subtensor_module_test.go
@@ -204,4 +204,44 @@ func TestSubtensorModuleExtrinsics(t *testing.T) {
 		t.Logf("Bob's final balance: %v TAO", finalBalance)
 		require.Equal(t, initialBalance-uint64(amount_staked), finalBalance, "Balance should decrease by staked amount")
 	})
+
+	t.Run("CommitCRV3Weights", func(t *testing.T) {
+		t.Parallel()
+		env := setup(t)
+
+		// Create test parameters
+		netuid := types.U16(1)
+		commit := types.Bytes([]byte("test_commit_data"))
+		revealRound := types.U64(100)
+
+		// Test CommitCRV3WeightsCall
+		call, err := CommitCRV3WeightsCall(env.Client, netuid, commit, revealRound)
+		require.NoError(t, err, "Failed to create CommitCRV3WeightsCall")
+		require.NotNil(t, call)
+
+		// Test CommitCRV3WeightsExt
+		ext, err := CommitCRV3WeightsExt(env.Client, netuid, commit, revealRound)
+		require.NoError(t, err, "Failed to create CommitCRV3WeightsExt")
+		require.NotNil(t, ext)
+	})
+
+	t.Run("CommitTimelockedWeights", func(t *testing.T) {
+		t.Parallel()
+		env := setup(t)
+
+		// Create test parameters
+		netuid := types.U16(1)
+		commit := types.Bytes([]byte("test_timelocked_data"))
+		revealRound := types.U64(100)
+
+		// Test CommitTimelockedWeightsCall
+		call, err := CommitTimelockedWeightsCall(env.Client, netuid, commit, revealRound)
+		require.NoError(t, err, "Failed to create CommitTimelockedWeightsCall")
+		require.NotNil(t, call)
+
+		// Test CommitTimelockedWeightsExt
+		ext, err := CommitTimelockedWeightsExt(env.Client, netuid, commit, revealRound)
+		require.NoError(t, err, "Failed to create CommitTimelockedWeightsExt")
+		require.NotNil(t, ext)
+	})
 }

--- a/extrinsics/timelocked.go
+++ b/extrinsics/timelocked.go
@@ -1,0 +1,80 @@
+package extrinsics
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../third_party/bittensor-drand
+#cgo LDFLAGS: -L${SRCDIR}/../third_party/bittensor-drand/target/release -lbittensor_drand -ldl
+#include "bindings.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// GenerateCommit computes the encrypted CRv4 commit and returns the bytes + reveal round.
+func GenerateCommit(
+	uids []uint16,
+	vals []uint16,
+	versionKey uint64,
+	tempo uint64,
+	currentBlock uint64,
+	netuid uint16,
+	revealEpochs uint64,
+	blockTime float64,
+	hotkey []byte,
+) ([]byte, uint64, error) {
+	if len(uids) != len(vals) {
+		return nil, 0, fmt.Errorf("uids and vals must have same length")
+	}
+
+	// Prepare C pointers
+	uPtr := (*C.uint16_t)(unsafe.Pointer(&uids[0]))
+	vPtr := (*C.uint16_t)(unsafe.Pointer(&vals[0]))
+	length := C.size_t(len(uids))
+	
+	var hotkeyPtr *C.uint8_t
+	var hotkeyLen C.size_t
+	if len(hotkey) > 0 {
+		hotkeyPtr = (*C.uint8_t)(unsafe.Pointer(&hotkey[0]))
+		hotkeyLen = C.size_t(len(hotkey))
+	}
+
+	var cRound C.uint64_t
+	var cErr *C.char
+
+	// Call into the Rust library
+	buf := C.cr_generate_commit(
+		uPtr, length,
+		vPtr, length,
+		C.uint64_t(versionKey),
+		C.uint64_t(tempo),
+		C.uint64_t(currentBlock),
+		C.uint16_t(netuid),
+		C.uint64_t(revealEpochs),
+		C.double(blockTime),
+		hotkeyPtr, hotkeyLen,
+		&cRound,
+		&cErr,
+	)
+
+	if cErr != nil {
+		err := fmt.Errorf("error from Rust: %s", C.GoString(cErr))
+		C.cr_free_str(cErr)
+		return nil, 0, err
+	}
+
+	if buf.ptr == nil {
+		return nil, 0, fmt.Errorf("received nil buffer from Rust")
+	}
+
+	// Convert C buffer to Go slice
+	goBytes := C.GoBytes(unsafe.Pointer(buf.ptr), C.int(buf.len))
+	
+	// Free the Rust-allocated buffer
+	C.cr_free(buf)
+
+	revealRound := uint64(cRound)
+
+	return goBytes, revealRound, nil
+}

--- a/extrinsics/timelocked_test.go
+++ b/extrinsics/timelocked_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+// +build integration
+
+package extrinsics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCommit(t *testing.T) {
+	env := setup(t)
+	defer env.Teardown()
+
+	// Test parameters
+	uids := []uint16{0, 1, 2}
+	vals := []uint16{100, 200, 300}
+	versionKey := uint64(843000)
+	tempo := uint64(360)
+	currentBlock := uint64(1000)
+	netuid := uint16(1)
+	revealEpochs := uint64(10)
+	blockTime := 1.0
+	hotkey := env.Bob.Hotkey.Keypair.PublicKey
+
+	// Test GenerateCommit
+	commitBytes, revealRound, err := GenerateCommit(
+		uids,
+		vals,
+		versionKey,
+		tempo,
+		currentBlock,
+		netuid,
+		revealEpochs,
+		blockTime,
+		hotkey,
+	)
+
+	require.NoError(t, err, "Failed to generate commit")
+	require.NotEmpty(t, commitBytes, "Generated commit should not be empty")
+	require.Greater(t, revealRound, currentBlock, "Reveal round should be greater than current block")
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// VersionKey is used for commit generation in the bittensor network
+const VersionKey = 843000


### PR DESCRIPTION
Continuing #24 but off of master branch instead of old crv3 branch.

Currently I've only tested via unit tests with the `manifoldlabs/subtensor:fast-block` image but it does not have commit_timelocked_weights, so I've left in commit_crv3_weights for now to make sure at least one of the tests pass.

## Copy of old description:
Notes:
- I made `third_party/bittensor-drand` a git submodule so that it's more robust to changes. Right now, the git submodule points to my own fork at https://github.com/tb-team-dev-2/bittensor-drand but this should prob be changed to a subtrahend-labs/bittensor-drand fork that would just sync whenever opentensor/bittensor-drand is changed. This can be done with: `git submodule set-url third_party/bittensor-drand https://github.com/subtrahend-labs/bittensor-drand`. If the git submodule is not wanted, I can always remove it and then we could just manually copy whenever there are changes to opentensor/bittensor-drand
- The bindings.h file just needed a small update in the generate commit function to handle an extra hotkey arg, then tests started passing
- On first pull, you will need to run `git submodule update --init --recursive` to setup the git submodule

Todo:
- [ ] docs for setup (build with `cargo build --release --no-default-features`)
- [x] use `commit_timelocked_weights`extrinsic instead of `commit_crv3_weights` extrinsic
- [ ] make sure logic matches: https://github.com/opentensor/bittensor/pull/2999